### PR TITLE
Fix nested upsert (array and upsert.update.create) bugs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,49 +136,28 @@ export const processNestedData = <T extends ModelName>(
               };
             } else if (key === "upsert") {
               // Handle upsert operation (has create and update)
-              if (Array.isArray(value)) {
-                result[key] = value.map((item: any) => ({
-                  ...item,
-                  create: item.create
-                    ? processNestedData(
-                        item.create,
-                        relatedModel as T,
-                        prefixedId,
-                        dmmf,
-                      )
-                    : item.create,
-                  update: item.update
-                    ? processNestedData(
-                        item.update,
-                        relatedModel as T,
-                        prefixedId,
-                        dmmf,
-                        false,
-                      )
-                    : item.update,
-                }));
-              } else {
-                result[key] = {
-                  ...value,
-                  create: value.create
-                    ? processNestedData(
-                        value.create,
-                        relatedModel as T,
-                        prefixedId,
-                        dmmf,
-                      )
-                    : value.create,
-                  update: value.update
-                    ? processNestedData(
-                        value.update,
-                        relatedModel as T,
-                        prefixedId,
-                        dmmf,
-                        false,
-                      )
-                    : value.update,
-                };
-              }
+              const upsertItems = Array.isArray(value) ? value : [value];
+              const processedUpserts = upsertItems.map((item: any) => ({
+                ...item,
+                create: item.create
+                  ? processNestedData(
+                      item.create,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                    )
+                  : item.create,
+                update: item.update
+                  ? processNestedData(
+                      item.update,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                      false,
+                    )
+                  : item.update,
+              }));
+              result[key] = Array.isArray(value) ? processedUpserts : processedUpserts[0];
             } else if (key === "connectOrCreate") {
               // Handle connectOrCreate operation
               result[key] = {
@@ -231,49 +210,28 @@ export const processNestedData = <T extends ModelName>(
               ),
             };
           } else if (op === "upsert") {
-            if (Array.isArray(value[op])) {
-              updatedValue[op] = value[op].map((item: any) => ({
-                ...item,
-                create: item.create
-                  ? processNestedData(
-                      item.create,
-                      relatedModel as T,
-                      prefixedId,
-                      dmmf,
-                    )
-                  : item.create,
-                update: item.update
-                  ? processNestedData(
-                      item.update,
-                      relatedModel as T,
-                      prefixedId,
-                      dmmf,
-                      false,
-                    )
-                  : item.update,
-              }));
-            } else {
-              updatedValue[op] = {
-                ...value[op],
-                create: value[op].create
-                  ? processNestedData(
-                      value[op].create,
-                      relatedModel as T,
-                      prefixedId,
-                      dmmf,
-                    )
-                  : value[op].create,
-                update: value[op].update
-                  ? processNestedData(
-                      value[op].update,
-                      relatedModel as T,
-                      prefixedId,
-                      dmmf,
-                      false,
-                    )
-                  : value[op].update,
-              };
-            }
+            const upsertItems = Array.isArray(value[op]) ? value[op] : [value[op]];
+            const processedUpserts = upsertItems.map((item: any) => ({
+              ...item,
+              create: item.create
+                ? processNestedData(
+                    item.create,
+                    relatedModel as T,
+                    prefixedId,
+                    dmmf,
+                  )
+                : item.create,
+              update: item.update
+                ? processNestedData(
+                    item.update,
+                    relatedModel as T,
+                    prefixedId,
+                    dmmf,
+                    false,
+                  )
+                : item.update,
+            }));
+            updatedValue[op] = Array.isArray(value[op]) ? processedUpserts : processedUpserts[0];
           } else if (op === "connectOrCreate") {
             // Special handling for connectOrCreate - it's an array where each item has where/create
             if (Array.isArray(value[op])) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,18 +136,49 @@ export const processNestedData = <T extends ModelName>(
               };
             } else if (key === "upsert") {
               // Handle upsert operation (has create and update)
-              result[key] = {
-                ...value,
-                create: value.create
-                  ? processNestedData(
-                      value.create,
-                      relatedModel as T,
-                      prefixedId,
-                      dmmf,
-                    )
-                  : value.create,
-                update: value.update,
-              };
+              if (Array.isArray(value)) {
+                result[key] = value.map((item: any) => ({
+                  ...item,
+                  create: item.create
+                    ? processNestedData(
+                        item.create,
+                        relatedModel as T,
+                        prefixedId,
+                        dmmf,
+                      )
+                    : item.create,
+                  update: item.update
+                    ? processNestedData(
+                        item.update,
+                        relatedModel as T,
+                        prefixedId,
+                        dmmf,
+                        false,
+                      )
+                    : item.update,
+                }));
+              } else {
+                result[key] = {
+                  ...value,
+                  create: value.create
+                    ? processNestedData(
+                        value.create,
+                        relatedModel as T,
+                        prefixedId,
+                        dmmf,
+                      )
+                    : value.create,
+                  update: value.update
+                    ? processNestedData(
+                        value.update,
+                        relatedModel as T,
+                        prefixedId,
+                        dmmf,
+                        false,
+                      )
+                    : value.update,
+                };
+              }
             } else if (key === "connectOrCreate") {
               // Handle connectOrCreate operation
               result[key] = {
@@ -200,18 +231,49 @@ export const processNestedData = <T extends ModelName>(
               ),
             };
           } else if (op === "upsert") {
-            updatedValue[op] = {
-              ...value[op],
-              create: value[op].create
-                ? processNestedData(
-                    value[op].create,
-                    relatedModel as T,
-                    prefixedId,
-                    dmmf,
-                  )
-                : value[op].create,
-              update: value[op].update, // Don't process update
-            };
+            if (Array.isArray(value[op])) {
+              updatedValue[op] = value[op].map((item: any) => ({
+                ...item,
+                create: item.create
+                  ? processNestedData(
+                      item.create,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                    )
+                  : item.create,
+                update: item.update
+                  ? processNestedData(
+                      item.update,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                      false,
+                    )
+                  : item.update,
+              }));
+            } else {
+              updatedValue[op] = {
+                ...value[op],
+                create: value[op].create
+                  ? processNestedData(
+                      value[op].create,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                    )
+                  : value[op].create,
+                update: value[op].update
+                  ? processNestedData(
+                      value[op].update,
+                      relatedModel as T,
+                      prefixedId,
+                      dmmf,
+                      false,
+                    )
+                  : value[op].update,
+              };
+            }
           } else if (op === "connectOrCreate") {
             // Special handling for connectOrCreate - it's an array where each item has where/create
             if (Array.isArray(value[op])) {


### PR DESCRIPTION
Hi, thanks for working on this great project!

I've been trying to integrate this recently and ran into some issues which led me to making this PR - I hope it fixes 2 bugs related to upsert logic:

- when the `upsert` had an Array value, we were defaulting to the first item instead of calling `processNestedData` on each individual item
- when the `upsert.update` had a nested `create`, we weren't adding the prefixed ID to them

I've split this out into a few commits for easier reviewing, so you can also check the initial test results yourself!

(also happy to drop the last commit if you feel it's less readable, I tried to reduce some of the duplicated logic I introduced but of course happy either way)